### PR TITLE
Fix missing endblock tags in templates causing 500 errors

### DIFF
--- a/app/templates/history.html
+++ b/app/templates/history.html
@@ -87,3 +87,4 @@
 {% else %}
 <p>No repositories found for the selected date.</p>
 {% endif %}
+{% endblock %}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -67,7 +67,7 @@
 <div class="text-center mt-4">
     <a href="https://github.com/trending?since=weekly" target="_blank" class="btn btn-secondary">View on GitHub</a>
 </div>
-</div>
+{% endblock %}
 
 <!-- Bootstrap JS and dependencies -->
 <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>

--- a/app/templates/repository_detail.html
+++ b/app/templates/repository_detail.html
@@ -94,3 +94,4 @@
             </div>
         </div>
     </div>
+{% endblock %}


### PR DESCRIPTION
This PR fixes missing `{% endblock %}` tags in several templates that were causing 500 errors when rendering the pages. The affected files are:
- app/templates/index.html
- app/templates/repository_detail.html
- app/templates/history.html

The fix ensures proper template inheritance by adding the missing endblock tags at the end of each file.